### PR TITLE
Fix mentioning wrong command

### DIFF
--- a/static/docs/get-started/connect-code-and-data.md
+++ b/static/docs/get-started/connect-code-and-data.md
@@ -47,7 +47,7 @@ run `dvc push`, usually along with git commit to save them to the remote when
 you done.
 
 > We don't do it here and in the next chapters to keep commands as simple as
-possible, but it's recommended to use `-f` optional argument that `dvc add`
+possible, but it's recommended to use `-f` optional argument that `dvc run`
 provides to specify a meaningful stage name.
 
 Let's commit metafiles to save the stage we built:


### PR DESCRIPTION
`dvc add` does not have `-f` parameter, but `dvc run` has and it's description matches surrounding context.